### PR TITLE
Adds Orca Var and Puma/Cougar Var

### DIFF
--- a/addons/base_vehicles/CfgVehicles_Orca.hpp
+++ b/addons/base_vehicles/CfgVehicles_Orca.hpp
@@ -1,11 +1,11 @@
 class O_Heli_Light_02_unarmed_F;
 class GCLASS(Orca): O_Heli_Light_02_unarmed_F {
-    displayName = "Orca";
+    displayName = "PO-30 Orca";
     faction = QGCLASS(base_vehicles);
     SCOPE_DLC_VEHICLE;
     EMPTY_INVENTORY;
     ace_refuel_fuelCapacity = 1800;
-    textureList[] = {"Black",1,"Blackcustom",1,"Blue",1,"Green",1,"CIV",1};
+    textureList[] = {"Black",1,"Blackcustom",1,"Green",1,"CIV",1};
     class TextureSources {
         class Opfor {
             displayName = "Hex Ochre";
@@ -21,11 +21,6 @@ class GCLASS(Orca): O_Heli_Light_02_unarmed_F {
             displayName = "Orca";
             textures[] = {"\A3\Air_F_Heli\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_V2_CO.paa"};
             faction[] = {};
-        };
-        class Blue {
-            displayName = "White & Blue";
-            textures[] = {"\a3\air_f\Heli_Light_02\Data\heli_light_02_ext_civilian_co.paa"};
-            factions[] = {};
         };
         class Indep {
             displayName = "DAP Woodland";
@@ -70,6 +65,280 @@ class GCLASS(Orca): O_Heli_Light_02_unarmed_F {
         class Ardistan {
             displayName = "Ardistan";
             textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_ardi_CO.paa"};
+            faction[] = {};
+        };
+        class ION_BLACK
+        {
+            displayName = "ION Services";
+            textures[] = {"\lxWS\air_f_lxWS\Heli_Light_02\data\Heli_Light_02_ext_ion_CO.paa"};
+            faction[] = {};
+        };
+        class BlackStar
+        {
+            displayName = "Black (Star)";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_RUS_CO.paa"};
+            faction[] = {};
+        };
+    };
+};
+
+class O_Heli_Light_02_dynamicLoadout_F;
+class GCLASS(OrcaArmed): O_Heli_Light_02_dynamicLoadout_F {
+    displayName = "PO-30A Orca";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    ace_refuel_fuelCapacity = 1800;
+    textureList[] = {"Black",1,"Blackcustom",1,"Green",1,"CIV",1};
+    class TextureSources {
+        class Opfor {
+            displayName = "Hex Ochre";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_CO.paa"};
+            faction[] = {};
+        };
+        class Black {
+            displayName = "Black";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_CO.paa"};
+            faction[] = {};
+        };
+        class Blackcustom {
+            displayName = "Orca";
+            textures[] = {"\A3\Air_F_Heli\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_V2_CO.paa"};
+            faction[] = {};
+        };
+        class Indep {
+            displayName = "DAP Woodland";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_INDP_CO.paa"};
+            factions[] = {};
+        };
+        class GreenHex {
+            displayName = "Hex Woodland";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_ghex_CO.paa"};
+            faction[] = {};
+        };
+        class Green {
+            displayName = "Olive";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_raven_CO.paa"};
+            faction[] = {};
+        };
+        class CIV {
+            displayName = "White & Blue";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_Civilian_CO.paa"};
+            factions[] = {};
+        };
+        class Marar {
+            displayName = "Marar";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_Marar_CO.paa"};
+            faction[] = {};
+        };
+        class UNO {
+            displayName = "United Nations";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_UN_CO.paa"};
+            faction[] = {};
+        };
+        class WoodlandHex {
+            displayName = "Hex Green";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_whex_CO.paa"};
+            faction[] = {};
+        };
+        class Takistan {
+            displayName = "Hex Mixed";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_tk_CO.paa"};
+            faction[] = {};
+        };
+        class Ardistan {
+            displayName = "Ardistan";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_ardi_CO.paa"};
+            faction[] = {};
+        };
+        class ION_BLACK
+        {
+            displayName = "ION Services";
+            textures[] = {"\lxWS\air_f_lxWS\Heli_Light_02\data\Heli_Light_02_ext_ion_CO.paa"};
+            faction[] = {};
+        };
+        class BlackStar
+        {
+            displayName = "Black (Star)";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_RUS_CO.paa"};
+            faction[] = {};
+        };
+    };
+};
+
+class B_ION_Heli_Light_02_unarmed_lxWS;
+class GCLASS(OrcaR): B_ION_Heli_Light_02_unarmed_lxWS {
+    displayName = "PO-30R Orca";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    ace_refuel_fuelCapacity = 1800;
+    textureList[] = {"Black",1,"Blackcustom",1,"Green",1,"CIV",1};
+    class TextureSources {
+        class Opfor
+        {
+            displayName = "Hex Ochre";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_bhex_co.paa"};
+            faction[] = {};
+        };
+        class GreenHex
+        {
+            displayName = "Hex Woodland";
+            textures[] = {"\lxWS\air_f_lxWS\heli_light_02\data\Heli_Light_02_ext_ghex_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            factions[] = {};
+        };
+        class ION_BLACK
+        {
+            displayName = "ION Services";
+            textures[] = {"\lxWS\air_f_lxWS\Heli_Light_02\data\Heli_Light_02_ext_ion_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Black
+        {
+            displayName = "Black";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Blackcustom
+        {
+            displayName = "Orca";
+            textures[] = {"\A3\Air_F_Heli\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_V2_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Blue
+        {
+            displayName = "White & Blue";
+            textures[] = {"\a3\air_f\Heli_Light_02\Data\heli_light_02_ext_civilian_co.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            factions[] = {};
+        };
+        class Ardistan {
+            displayName = "Ardistan";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_ardi_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            faction[] = {};
+        };
+        class WoodlandHex {
+            displayName = "Hex Green";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_whex_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            faction[] = {};
+        };
+        class Takistan {
+            displayName = "Hex Mixed";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_tk_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_bhex_co.paa"};
+            faction[] = {};
+        };
+        class Marar {
+            displayName = "Marar";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_Marar_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class UNO {
+            displayName = "United Nations";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_UN_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Green {
+            displayName = "Olive";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_raven_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            faction[] = {};
+        };
+        class Indep {
+            displayName = "DAP Woodland";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_INDP_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            factions[] = {};
+        };
+        class BlackStar
+        {
+            displayName = "Black (Star)";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_RUS_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+    };
+};
+
+class B_ION_Heli_Light_02_dynamicLoadout_lxWS;
+class GCLASS(OrcaAR): B_ION_Heli_Light_02_dynamicLoadout_lxWS {
+    displayName = "PO-30AR Orca";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    ace_refuel_fuelCapacity = 1800;
+    textureList[] = {"Black",1,"Blackcustom",1,"Green",1,"CIV",1};
+    class TextureSources {
+        class Opfor
+        {
+            displayName = "Hex Ochre";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_bhex_co.paa"};
+            faction[] = {};
+        };
+        class GreenHex
+        {
+            displayName = "Hex Woodland";
+            textures[] = {"\lxWS\air_f_lxWS\heli_light_02\data\Heli_Light_02_ext_ghex_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            factions[] = {};
+        };
+        class ION_BLACK
+        {
+            displayName = "ION Services";
+            textures[] = {"\lxWS\air_f_lxWS\Heli_Light_02\data\Heli_Light_02_ext_ion_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Black
+        {
+            displayName = "Black";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Blackcustom
+        {
+            displayName = "Orca";
+            textures[] = {"\A3\Air_F_Heli\Heli_Light_02\Data\Heli_Light_02_ext_OPFOR_V2_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Blue
+        {
+            displayName = "White & Blue";
+            textures[] = {"\a3\air_f\Heli_Light_02\Data\heli_light_02_ext_civilian_co.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            factions[] = {};
+        };
+        class Ardistan {
+            displayName = "Ardistan";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_ardi_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            faction[] = {};
+        };
+        class WoodlandHex {
+            displayName = "Hex Green";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_whex_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            faction[] = {};
+        };
+        class Takistan {
+            displayName = "Hex Mixed";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_tk_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_bhex_co.paa"};
+            faction[] = {};
+        };
+        class Marar {
+            displayName = "Marar";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_Marar_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class UNO {
+            displayName = "United Nations";
+            textures[] = {"\A3_Atlas\Air_F_Atlas\Heli_Light_02\Data\Heli_Light_02_ext_UN_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            faction[] = {};
+        };
+        class Green {
+            displayName = "Olive";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_raven_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ghex_co.paa"};
+            faction[] = {};
+        };
+        class Indep {
+            displayName = "DAP Woodland";
+            textures[] = {"\A3\Air_F\Heli_Light_02\Data\Heli_Light_02_ext_INDP_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
+            factions[] = {};
+        };
+        class BlackStar
+        {
+            displayName = "Black (Star)";
+            textures[] = {"\A3_Aegis\Air_F_Aegis\Heli_Light_02\Data\Heli_Light_02_ext_RUS_CO.paa","\a3\air_f\data\rockets_co.paa","\lxWS\air_f_lxWS\heli_light_02\data\lxws_heli_light_02_adds_ion_co.paa"};
             faction[] = {};
         };
     };

--- a/addons/base_vehicles/CfgVehicles_Puma.hpp
+++ b/addons/base_vehicles/CfgVehicles_Puma.hpp
@@ -10,30 +10,6 @@ class GCLASS(Puma): C_Heli_EC_01_civ_RF {
     #include "textures\Puma.hpp"
 };
 
-class C_Heli_EC_04_rescue_RF;
-class GCLASS(Puma_Rescue): C_Heli_EC_04_rescue_RF {
-    displayName ="H225 Super Puma (Rescue)";
-    faction = QGCLASS(base_vehicles);
-    SCOPE_DLC_VEHICLE;
-    EMPTY_INVENTORY;
-    crew = "Civilian";
-    typicalCargo[] = {"Soldier"};
-    ace_refuel_fuelCapacity = 1680;
-    #include "textures\Puma.hpp"
-};
-
-class I_Heli_EC_02_RF;
-class GCLASS(Puma_Pylons): I_Heli_EC_02_RF {
-    displayName ="H225M Super Couagar";
-    faction = QGCLASS(base_vehicles);
-    SCOPE_DLC_VEHICLE;
-    EMPTY_INVENTORY;
-    crew = "Civilian";
-    typicalCargo[] = {"Soldier"};
-    ace_refuel_fuelCapacity = 1680;
-    #include "textures\Puma.hpp"
-};
-
 class C_Heli_EC_01A_civ_RF;
 class GCLASS(PumaA): C_Heli_EC_01A_civ_RF {
     displayName ="H215 Super Puma";
@@ -43,5 +19,77 @@ class GCLASS(PumaA): C_Heli_EC_01A_civ_RF {
     crew = "Civilian";
     typicalCargo[] = {"Soldier"};
     ace_refuel_fuelCapacity = 1480;
+    #include "textures\Puma.hpp"
+};
+
+class I_Heli_EC_01A_military_RF;
+class GCLASS(PumaM): I_Heli_EC_01A_military_RF {
+    displayName ="H215M Super Puma";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    crew = "Civilian";
+    typicalCargo[] = {"Soldier"};
+    ace_refuel_fuelCapacity = 1480;
+    #include "textures\Puma.hpp"
+};
+
+class B_ION_Heli_EC_01_RF;
+class GCLASS(PumaT): B_ION_Heli_EC_01_RF {
+    displayName ="H225M Super Puma";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    crew = "Civilian";
+    typicalCargo[] = {"Soldier"};
+    ace_refuel_fuelCapacity = 1680;
+    #include "textures\Puma.hpp"
+};
+
+class B_Heli_EC_04_military_RF;
+class GCLASS(Cougar): B_Heli_EC_04_military_RF {
+    displayName ="H225M Super Cougar";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    crew = "Civilian";
+    typicalCargo[] = {"Soldier"};
+    ace_refuel_fuelCapacity = 1680;
+    #include "textures\Puma.hpp"
+};
+
+class B_Heli_EC_03_RF;
+class GCLASS(Cougar_Armed): B_Heli_EC_03_RF {
+    displayName ="H225M Super Cougar (Armed)";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    crew = "Civilian";
+    typicalCargo[] = {"Soldier"};
+    ace_refuel_fuelCapacity = 1680;
+    #include "textures\Puma.hpp"
+};
+
+class I_E_EC_02_RF;
+class GCLASS(Cougar_Pylon): I_E_EC_02_RF {
+    displayName ="H225M Super Cougar SOCAT";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    crew = "Civilian";
+    typicalCargo[] = {"Soldier"};
+    ace_refuel_fuelCapacity = 1680;
+    #include "textures\Puma.hpp"
+};
+
+class C_Heli_EC_04_rescue_RF;
+class GCLASS(Cougar_Rescue): C_Heli_EC_04_rescue_RF {
+    displayName ="H225 Super Cougar SAR";
+    faction = QGCLASS(base_vehicles);
+    SCOPE_DLC_VEHICLE;
+    EMPTY_INVENTORY;
+    crew = "Civilian";
+    typicalCargo[] = {"Soldier"};
+    ace_refuel_fuelCapacity = 1680;
     #include "textures\Puma.hpp"
 };


### PR DESCRIPTION
Adds UpArmored Versions of Orca (along with ION livery)
- Changes "PO-30 Orca (Armed)" to "PO-30A Orca"
- Adds Unarmed UpAr Orcas as "PO-30R Orca"
- Adds Armed & UpAr Orcas as "PO-30AR Orca"

Adds Missing versions of the Puma with new naming scheme as follows:
- Has CMDS and/or Military style seating, designated with "M" at the end of product number
- Chasis has EO/IR, designated as "Cougar". N/A, "Puma"
- Flotation Device, 225, N/A, 215
- Current "H225M Super Cougar (Armed)" has been changed to H225M Super Cougar SOCAT, with new "H225M Super Cougar (Armed)" variant to take its place
- Changes "H225 Super Puma (Rescue)" to "H225 Super Cougar SAR"
- All this is essentially to say that it's name about the same as it is in vanilla, except for the SAR model (being changed from what we currently have it named in the modpack)