### PR TITLE
Karskoya Rifle & Others Update

### DIFF
--- a/addons/karskoya/army_combat/CfgVehicles.hpp
+++ b/addons/karskoya/army_combat/CfgVehicles.hpp
@@ -32,7 +32,6 @@ class CfgVehicles {
             "packs": [
                 "t3_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 
@@ -58,7 +57,7 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_02_blk_F": {
+                "JCA_arifle_M4A1_black_F": {
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
                     },
@@ -69,7 +68,7 @@ class CfgVehicles {
                 "optic_VRCO_RF": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
         });
     };
@@ -84,7 +83,6 @@ class CfgVehicles {
             "packs": [
                 "t3_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
             "magazines": {
                 "SmokeShellRed": 1,
@@ -108,7 +106,7 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_GL_blk_F": {
+                "JCA_arifle_M4A1_GL_black_F": {
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
                         "1Rnd_HE_Grenade_shell": 4,
@@ -122,17 +120,7 @@ class CfgVehicles {
                 "optic_VRCO_RF": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
-            },
-        });
-
-        @Secondary({
-            "weapons": {
-                "hgun_Pistol_heavy_01_black_F": {
-                    "magazinesVest": {
-                        "11Rnd_45ACP_Mag": 2,
-                    },
-                },
+                "Aegis_acc_pointer_DM": 1,
             },
         });
     };
@@ -155,7 +143,7 @@ class CfgVehicles {
                 "Aegis_optic_ICO": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
         });
 
@@ -179,17 +167,6 @@ class CfgVehicles {
     class CLASS(Machinegunner): CLASS(Autorifleman) {
         @Role(Machinegunner);
 
-        @Vests({
-            "variants": {
-                "WSLV_Platecarrier_WDL_NF": 1,
-            },
-            "packs": [
-                "t3_standard",
-                "military_standard",
-                "rifleman_medical",
-            ],
-        });
-
         @Primary({
             "weapons": {
                 "MMG_01_black_F": {
@@ -202,7 +179,7 @@ class CfgVehicles {
                 },
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
         });
 
@@ -241,17 +218,17 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_03_blk_F": {
+                "JCA_arifle_SR25_black_F": {
                     "magazinesVest": {
-                        "20Rnd_762x51_Mag": 8,
+                        "JCA_20Rnd_762x51_SMAG": 7,
                     }
                 }
             },
             "optics": {
-                "optic_AMS": 1,
+                "JCA_optic_MRPS_black": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "bipods": {
                 "bipod_01_F_blk": 1,
@@ -285,17 +262,6 @@ class CfgVehicles {
     class CLASS(RiflemanMAT): CLASS(Rifleman) {
         @Role(RiflemanMAT);
 
-        @Vests({
-            "variants": {
-                "WSLV_Platecarrier_WDL_NF": 1,
-            },
-            "packs": [
-                "t3_standard",
-                "military_standard",
-                "rifleman_medical",
-            ],
-        });
-
         @Launchers({
             "weapons": {
                 "launch_RPG32_green_F": {
@@ -317,17 +283,6 @@ class CfgVehicles {
     class CLASS(RiflemanAA): CLASS(Rifleman) {
         @Role(RiflemanAA);
 
-        @Vests({
-            "variants": {
-                "WSLV_Platecarrier_WDL_NF": 1,
-            },
-            "packs": [
-                "t3_standard",
-                "military_standard",
-                "rifleman_medical",
-            ],
-        });
-
         @Launchers({
             "weapons": {
                 "launch_B_Titan_olive_F": {
@@ -347,17 +302,6 @@ class CfgVehicles {
 
     class CLASS(RiflemanHAT): CLASS(Rifleman) {
         @Role(RiflemanHAT);
-
-        @Vests({
-            "variants": {
-                "WSLV_Platecarrier_WDL_NF": 1,
-            },
-            "packs": [
-                "t3_standard",
-                "military_standard",
-                "rifleman_medical",
-            ],
-        });
 
         @Launchers({
             "weapons": {
@@ -398,29 +342,18 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_blk_F": {
+                "JCA_arifle_M4A1_short_black_F": {
                     "magazinesVest": {
-                        "30Rnd_556x45_Stanag_red": 4,
+                        "30Rnd_556x45_Stanag_red": 7,
                     }
                 },
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "optics": {
                 "Aegis_optic_ICO": 1,
             },
-        });
-
-        @Vests({
-            "variants": {
-                "WSLV_Platecarrier_WDL_NF": 1,
-            },
-            "packs": [
-                "t3_standard",
-                "military_standard",
-                "rifleman_medical",
-            ],
         });
 
         @Backpacks({
@@ -438,14 +371,14 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_blk_F": {
+                "JCA_arifle_M4A1_short_black_F": {
                     "magazinesVest": {
-                        "30Rnd_556x45_Stanag_red": 5,
+                        "30Rnd_556x45_Stanag_red": 7,
                     }
                 },
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "optics": {
                 "Aegis_optic_ICO": 1,
@@ -472,23 +405,12 @@ class CfgVehicles {
     class CLASS(Crewman): CLASS(Base) {
         @Role(Crewman);
 
-        @Uniforms({
-            "variants": {
-                "Atlas_U_UniformBDU_01_m81_F": 1,
-                "Atlas_U_UniformBDU_02_m81_F": 1,
-            },
-            "packs": [
-                "rifleman_medical",
-            ],
-        });
-
         @Vests({
             "variants": {
                 "V_Rangemaster_belt": 1,
             },
             "packs": [
                 "t3_standard",
-                "rifleman_medical",
             ],
         });
 
@@ -507,6 +429,16 @@ class CfgVehicles {
             "optics": {
                 "Aegis_optic_ICO": 1,
                 "": 1,
+            },
+        });
+
+        @Secondary({
+            "weapons": {
+                "hgun_Pistol_heavy_01_black_F": {
+                    "magazinesVest": {
+                        "11Rnd_45ACP_Mag": 2,
+                    },
+                },
             },
         });
     };
@@ -546,9 +478,5 @@ class CfgVehicles {
         @Facewear({
             "": 1,
         });
-    };
-
-    class CLASS(Hidden): CLASS(Base) {
-        @Role(Hidden);
     };
 };

--- a/addons/karskoya/army_garrison/CfgVehicles.hpp
+++ b/addons/karskoya/army_garrison/CfgVehicles.hpp
@@ -25,7 +25,6 @@ class CfgVehicles {
             },
             "packs": [
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 
@@ -51,7 +50,7 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_02_blk_F": {
+                "JCA_arifle_M4A1_black_F": {
                     "probability": 1,
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
@@ -73,7 +72,7 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_GL_blk_F": {
+                "JCA_arifle_M4A1_GL_black_F": {
                     "probability": 1,
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
@@ -179,6 +178,18 @@ class CfgVehicles {
             "variants": {
                 "V_Safety_blue_F": 1,
                 "V_Safety_yellow_F": 1,
+            },
+        });
+
+        @Secondary({
+            "weapons": {
+                "": 0.85,
+                "hgun_Pistol_heavy_01_black_F": {
+                    "probability": 0.15,
+                    "magazinesVest": {
+                        "11Rnd_45ACP_Mag": 3,
+                    },
+                },
             },
         });
     };

--- a/addons/karskoya/army_recon/CfgVehicles.hpp
+++ b/addons/karskoya/army_recon/CfgVehicles.hpp
@@ -20,13 +20,12 @@ class CfgVehicles {
 
         @Vests({
             "variants": {
-                "Aegis_V_TacVest_RigB_camo_RF": 1,
+                "V_lxWS_TacVestIR_oli": 1,
                 "V_TacChestrig_grn_F": 1,
             },
             "packs": [
                 "t3_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 
@@ -49,7 +48,7 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_02_blk_F": {
+                "JCA_arifle_M4A4_AFG_black_F": {
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
                     },
@@ -60,20 +59,10 @@ class CfgVehicles {
                 "optic_VRCO_RF": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "muzzles": {
                 "muzzle_snds_M": 1,
-            },
-        });
-
-        @Secondary({
-            "weapons": {
-                "hgun_ACPC2_black_F": {
-                    "magazinesVest": {
-                        "9Rnd_45ACP_Mag": 2,
-                    },
-                },
             },
         });
 
@@ -104,7 +93,7 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_GL_blk_F": {
+                "JCA_arifle_M4A4_GL_black_F": {
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
                         "1Rnd_HE_Grenade_shell": 4,
@@ -118,23 +107,13 @@ class CfgVehicles {
                 "optic_VRCO_RF": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "muzzles": {
                 "muzzle_snds_M": 1,
             },
         });
-
-        @Secondary({
-            "weapons": {
-                "hgun_ACPC2_black_F": {
-                    "magazinesVest": {
-                        "9Rnd_45ACP_Mag": 2,
-                    },
-                },
-            },
-        });
-    };
+};
 
     class CLASS(Autorifleman): CLASS(Base) {
         @Role(Autorifleman);
@@ -151,17 +130,7 @@ class CfgVehicles {
                 },
             },
             "pointers": {
-                "acc_pointer_IR": 1,
-            },
-        });
-
-        @Secondary({
-            "weapons": {
-                "hgun_ACPC2_black_F": {
-                    "magazinesVest": {
-                        "9Rnd_45ACP_Mag": 2,
-                    },
-                },
+                "Aegis_acc_pointer_DM": 1,
             },
         });
         
@@ -177,17 +146,17 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_03_blk_F": {
+                "JCA_arifle_SR25_black_F": {
                     "magazinesVest": {
-                        "20Rnd_762x51_Mag": 8,
+                        "JCA_20Rnd_762x51_SMAG": 8,
                     }
                 }
             },
             "optics": {
-                "optic_AMS": 1,
+                "JCA_optic_MRPS_black": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "bipods": {
                 "bipod_01_F_blk": 1,
@@ -286,7 +255,7 @@ class CfgVehicles {
         
         @Primary({
             "weapons": {
-                "arifle_SPAR_02_blk_F": {
+                "JCA_arifle_M4A4_AFG_black_F": {
                     "magazinesVest": {
                         "30Rnd_556x45_Stanag_red": 7,
                     },
@@ -296,7 +265,7 @@ class CfgVehicles {
                 "optic_VRCO_RF": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "muzzles": {
                 "muzzle_snds_M": 1,
@@ -319,7 +288,6 @@ class CfgVehicles {
             "packs": [
                 "t3_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 

--- a/addons/karskoya/special_forces/CfgVehicles.hpp
+++ b/addons/karskoya/special_forces/CfgVehicles.hpp
@@ -10,7 +10,7 @@ class CfgVehicles {
         @Uniforms({
             "variants": {
                 "synixe_mgp_g3_field_set_m81_rgr": 1,
-                "synixe_mgp_g3_field_set_m81_m81": 1,
+                "synixe_mgp_g3_field_set_m81_m81": 2,
             },
             "packs": [
                 "rifleman_medical",
@@ -24,7 +24,6 @@ class CfgVehicles {
             "packs": [
                 "t2_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 
@@ -37,16 +36,16 @@ class CfgVehicles {
             "synixe_mgp_f_tactical": 1,
             "synixe_mgp_f_face_shield_rgr_tactical": 1,
             "synixe_mgp_f_face_shield_rgr": 1,
-            "synixe_mgp_f_face_shield_blk": 0.5,
-            "synixe_mgp_f_face_shield_blk_tactical": 0.5,
+            "synixe_mgp_f_face_shield_blk": 1,
+            "synixe_mgp_f_face_shield_blk_tactical": 1,
         });
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_blk_F": {
+                "JCA_arifle_M4A4_AFG_black_F": {
                     "probability": 1,
                     "magazinesVest": {
-                        "30Rnd_556x45_AP_Stanag_red_RF": 6,
+                        "JCA_30Rnd_556x45_PMAG": 8,
                     },
                 },
             },
@@ -55,10 +54,10 @@ class CfgVehicles {
                 "optic_Holosight_blk_F": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "muzzles": {
-                "suppressor_l_lxWS": 1,
+                "JCA_muzzle_snds_556_Enhanced_black": 1,
             },
         });
 
@@ -94,7 +93,6 @@ class CfgVehicles {
             "packs": [
                 "t2_standard",
                 "military_standard",
-                "rifleman_medical",
                 "jtac",
             ],
         });
@@ -105,13 +103,13 @@ class CfgVehicles {
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_01_GL_blk_F": {
+                "JCA_arifle_M4A4_GL_black_F": {
                     "probability": 1,
                     "magazinesVest": {
-                        "30Rnd_556x45_AP_Stanag_red_RF": 8,
+                        "JCA_30Rnd_556x45_PMAG": 8,
                         "1Rnd_HE_Grenade_shell": 5,
                     },
-                    "loadedPrimary": "30Rnd_556x45_AP_Stanag_red_RF",
+                    "loadedPrimary": "JCA_30Rnd_556x45_PMAG",
                     "loadedSecondary": "1Rnd_HE_Grenade_shell",
                 },
             },
@@ -120,10 +118,10 @@ class CfgVehicles {
                 "JCA_optic_MROS_black_magnifier": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "muzzles": {
-                "suppressor_l_lxWS": 1,
+                "JCA_muzzle_snds_556_Enhanced_black": 1,
             },
         });
 
@@ -148,7 +146,6 @@ class CfgVehicles {
             "packs": [
                 "t2_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 
@@ -163,26 +160,16 @@ class CfgVehicles {
                         "Atlas_150Rnd_762x51_Box_Red": 3,
                     },
                 },
-                "arifle_SPAR_02_blk_F": {
-                    "probability": 1,                    
-                    "magazinesVest": {
-                        "75Rnd_556x45_Stanag_red_lxWS": 5,
-                    },
-                    "magazinesBackpack": {
-                        "75Rnd_556x45_Stanag_red_lxWS": 5,
-                    },
-                },
             },
             "optics": {
                 "optic_Holosight_blk_F": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "muzzles": {
                 "aegis_muzzle_snds_pbs_762_blk": 1,
-                "suppressor_l_lxWS": 1,
-            }
+            },
         });
 
         @Secondary({
@@ -212,29 +199,28 @@ class CfgVehicles {
             "packs": [
                 "t2_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 
         @Primary({
             "weapons": {
-                "arifle_SPAR_03_blk_F": {
+                "JCA_arifle_SR10_VFG_black_F": {
                     "magazinesVest": {
-                        "20Rnd_762x51_Mag": 8,
+                        "JCA_20Rnd_762x51_PMAG": 8,
                     }
                 }
             },
             "optics": {
-                "optic_AMS": 1,
+                "JCA_optic_CRBS_black": 1,
             },
             "pointers": {
-                "acc_pointer_IR": 1,
+                "Aegis_acc_pointer_DM": 1,
             },
             "bipods": {
                 "bipod_01_F_blk": 1,
             },
             "muzzles": {
-                "suppressor_h_lxWS": 1,
+                "JCA_muzzle_snds_762_tactical_black": 1,
             },
         });
     };
@@ -249,7 +235,6 @@ class CfgVehicles {
             "packs": [
                 "t2_standard",
                 "military_standard",
-                "rifleman_medical",
             ],
         });
 


### PR DESCRIPTION
The reason for the change is since the Virelia is using the 416 so it keeps them distinct them a little bit, as well as we didn't have the m4a4 when I made this and I think it works better with the overall look than the 416

- Removed all unnecessary rifleman_medical present
- Changed HK416 to M4A1 for Combat & garrison, while changing to M4A4 for Recon & SOF
- Changed 417 to SR25 for Combat/Recon, and SR10 for SOF
- Changed Various attachments (mainly muzzles and pointers, and the marksman scope)
- Under recon, changed tac vest to ELBV (cause it's ugly as hell)
- Removed incorrect handgun from Recon entirely (it was a 1911 not FNX)